### PR TITLE
Fix parameter http_service for Debian/Ubuntu

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -21,7 +21,7 @@ class horizon::params {
       $wsgi_group                  = 'dashboard'
     }
     'Debian': {
-      $http_service                = 'apache2'
+      $http_service                = 'httpd'
       $config_file                 = '/etc/openstack-dashboard/local_settings.py'
       $httpd_listen_config_file    = '/etc/apache2/ports.conf'
       $root_url                    = '/horizon'


### PR DESCRIPTION
Hello, 

this [line](https://github.com/openstack/puppet-horizon/blob/master/manifests/wsgi/apache.pp#L158) will make sure that Horizon is being installed before Apache2, but the [package](https://github.com/puppetlabs/puppetlabs-apache/blob/master/manifests/package.pp#L60) and [service](https://github.com/puppetlabs/puppetlabs-apache/blob/master/manifests/service.pp#L42) resources are using the name ```httpd``` and the distinction between ```.deb``` and ```.rpm``` is made by the parameters [apache_name/service_name](https://github.com/puppetlabs/puppetlabs-apache/blob/master/manifests/params.pp#L195-L196).

Kind regards,
Dennis