### PR TITLE
Support SSL Termination on Load Balancer

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -256,6 +256,10 @@
 #    (optional) The default theme to use from list of available themes. Value should be theme_name.
 #    Defaults to false
 #
+#  [*secure_proxy_ssl_header*]
+#    (optional) The header set by an SSL terminating proxy.
+#    Defaults to undef.
+#
 # === DEPRECATED group/name
 #
 #  [*fqdn*]
@@ -348,6 +352,7 @@ class horizon(
   $vhost_extra_params                  = undef,
   $available_themes                    = false,
   $default_theme                       = false,
+  $secure_proxy_ssl_header             = undef,
   # DEPRECATED PARAMETERS
   $custom_theme_path                   = undef,
   $fqdn                                = undef,

--- a/templates/local_settings.py.erb
+++ b/templates/local_settings.py.erb
@@ -43,9 +43,7 @@ ALLOWED_HOSTS = ['<%= @final_allowed_hosts %>', ]
 # https://docs.djangoproject.com/en/1.8/ref/settings/#secure-proxy-ssl-header
 #SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 <% if @secure_proxy_ssl_header %>
-SECURE_PROXY_SSL_HEADER = (<% @secure_proxy_ssl_header.sort.each do |header,value| -%>
-  '<%= header -%>', '<%= value -%>',
-<%end %>)
+SECURE_PROXY_SSL_HEADER = (<% @secure_proxy_ssl_header.sort.each do |header,value| -%>'<%= header -%>', '<%= value -%>'<%end %>)
 <% end %>
 
 # If Horizon is being served through SSL, then uncomment the following two

--- a/templates/local_settings.py.erb
+++ b/templates/local_settings.py.erb
@@ -42,6 +42,14 @@ ALLOWED_HOSTS = ['<%= @final_allowed_hosts %>', ]
 # For more information see:
 # https://docs.djangoproject.com/en/1.8/ref/settings/#secure-proxy-ssl-header
 #SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+<% if @secure_proxy_ssl_header %>
+
+SECURE_PROXY_SSL_HEADER = (<% @secure_proxy_ssl_header.sort.each do |header,value| -%>
+  '<%= header -%>', '<%= value -%>',
+<%end %>)
+
+SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+<% end %>
 
 # If Horizon is being served through SSL, then uncomment the following two
 # settings to better secure the cookies from security exploits

--- a/templates/local_settings.py.erb
+++ b/templates/local_settings.py.erb
@@ -43,12 +43,9 @@ ALLOWED_HOSTS = ['<%= @final_allowed_hosts %>', ]
 # https://docs.djangoproject.com/en/1.8/ref/settings/#secure-proxy-ssl-header
 #SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 <% if @secure_proxy_ssl_header %>
-
 SECURE_PROXY_SSL_HEADER = (<% @secure_proxy_ssl_header.sort.each do |header,value| -%>
   '<%= header -%>', '<%= value -%>',
 <%end %>)
-
-SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 <% end %>
 
 # If Horizon is being served through SSL, then uncomment the following two


### PR DESCRIPTION
To support SSL termination on a load balancer we must set 

`SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')`

Currently, the template for local_settings.py does not set this and there is no parameter in init.pp to support it. I adjusted init.pp and the ERB template to set these values.
